### PR TITLE
chore: Update links after move to margelo org

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@
 * **Customizable storage location**
 * **High performance** because everything is **written in C++**
 * **~30x faster than AsyncStorage**
-* Uses [**JSI**](https://reactnative.dev/docs/the-new-architecture/landing-page#fast-javascriptnative-interfacing) and [**C++ NitroModules**](https://github.com/mrousavy/nitro) instead of the "old" Bridge
+* Uses [**JSI**](https://reactnative.dev/docs/the-new-architecture/landing-page#fast-javascriptnative-interfacing) and [**C++ NitroModules**](https://github.com/margelo/nitro) instead of the "old" Bridge
 * **iOS**, **Android** and **Web** support
 * Easy to use **React Hooks** API
 
@@ -304,7 +304,7 @@ A mocked MMKV instance is automatically used when testing with Jest or Vitest, s
 * [Using MMKV with jotai](./docs/WRAPPER_JOTAI.md)
 * [Using MMKV with react-query](./docs/WRAPPER_REACT_QUERY.md)
 * [Using MMKV with Tinybase](./docs/WRAPPER_TINYBASE.md)
-* [How is this library different from **react-native-mmkv-storage**?](https://github.com/mrousavy/react-native-mmkv/issues/100#issuecomment-886477361)
+* [How is this library different from **react-native-mmkv-storage**?](https://github.com/margelo/react-native-mmkv/issues/100#issuecomment-886477361)
 
 ## LocalStorage and In-Memory Storage (Web)
 

--- a/README_V3.md
+++ b/README_V3.md
@@ -225,18 +225,18 @@ A mocked MMKV instance is automatically used when testing with Jest or Vitest, s
 
 ## Documentation
 
-* [Hooks](https://github.com/mrousavy/react-native-mmkv/blob/v3/docs/HOOKS.md)
-* [Value-change Listeners](https://github.com/mrousavy/react-native-mmkv/blob/v3/docs/LISTENERS.md)
-* [Migrate from AsyncStorage](https://github.com/mrousavy/react-native-mmkv/blob/v3/docs/MIGRATE_FROM_ASYNC_STORAGE.md)
-* [Using MMKV with redux-persist](https://github.com/mrousavy/react-native-mmkv/blob/v3/docs/WRAPPER_REDUX.md)
-* [Using MMKV with recoil](https://github.com/mrousavy/react-native-mmkv/blob/v3/docs/WRAPPER_RECOIL.md)
-* [Using MMKV with mobx-persist-storage](https://github.com/mrousavy/react-native-mmkv/blob/v3/docs/WRAPPER_MOBX.md)
-* [Using MMKV with mobx-persist](https://github.com/mrousavy/react-native-mmkv/blob/v3/docs/WRAPPER_MOBXPERSIST.md)
-* [Using MMKV with zustand persist-middleware](https://github.com/mrousavy/react-native-mmkv/blob/v3/docs/WRAPPER_ZUSTAND_PERSIST_MIDDLEWARE.md)
-* [Using MMKV with jotai](https://github.com/mrousavy/react-native-mmkv/blob/v3/docs/WRAPPER_JOTAI.md)
-* [Using MMKV with react-query](https://github.com/mrousavy/react-native-mmkv/blob/v3/docs/WRAPPER_REACT_QUERY.md)
-* [Using MMKV with Tinybase](https://github.com/mrousavy/react-native-mmkv/blob/v3/docs/WRAPPER_TINYBASE.md)
-* [How is this library different from **react-native-mmkv-storage**?](https://github.com/mrousavy/react-native-mmkv/issues/100#issuecomment-886477361)
+* [Hooks](https://github.com/margelo/react-native-mmkv/blob/v3/docs/HOOKS.md)
+* [Value-change Listeners](https://github.com/margelo/react-native-mmkv/blob/v3/docs/LISTENERS.md)
+* [Migrate from AsyncStorage](https://github.com/margelo/react-native-mmkv/blob/v3/docs/MIGRATE_FROM_ASYNC_STORAGE.md)
+* [Using MMKV with redux-persist](https://github.com/margelo/react-native-mmkv/blob/v3/docs/WRAPPER_REDUX.md)
+* [Using MMKV with recoil](https://github.com/margelo/react-native-mmkv/blob/v3/docs/WRAPPER_RECOIL.md)
+* [Using MMKV with mobx-persist-storage](https://github.com/margelo/react-native-mmkv/blob/v3/docs/WRAPPER_MOBX.md)
+* [Using MMKV with mobx-persist](https://github.com/margelo/react-native-mmkv/blob/v3/docs/WRAPPER_MOBXPERSIST.md)
+* [Using MMKV with zustand persist-middleware](https://github.com/margelo/react-native-mmkv/blob/v3/docs/WRAPPER_ZUSTAND_PERSIST_MIDDLEWARE.md)
+* [Using MMKV with jotai](https://github.com/margelo/react-native-mmkv/blob/v3/docs/WRAPPER_JOTAI.md)
+* [Using MMKV with react-query](https://github.com/margelo/react-native-mmkv/blob/v3/docs/WRAPPER_REACT_QUERY.md)
+* [Using MMKV with Tinybase](https://github.com/margelo/react-native-mmkv/blob/v3/docs/WRAPPER_TINYBASE.md)
+* [How is this library different from **react-native-mmkv-storage**?](https://github.com/margelo/react-native-mmkv/issues/100#issuecomment-886477361)
 
 ## LocalStorage and In-Memory Storage (Web)
 

--- a/docs/V4_UPGRADE_GUIDE.md
+++ b/docs/V4_UPGRADE_GUIDE.md
@@ -16,7 +16,7 @@ There have been a few breaking changes. This guide will help you migrate over fr
 
 ### Nitro Modules dependency
 
-Since react-native-mmkv is now a Nitro Module, you need to install the [react-native-nitro-modules](https://github.com/mrousavy/nitro) core dependency in your app:
+Since react-native-mmkv is now a Nitro Module, you need to install the [react-native-nitro-modules](https://github.com/margelo/nitro) core dependency in your app:
 
 ```sh
 npm install react-native-nitro-modules

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -77,9 +77,9 @@ android {
     buildToolsVersion = rootProject.ext.buildToolsVersion
     compileSdk = rootProject.ext.compileSdkVersion
 
-    namespace = "com.mrousavy.mmkv.example"
+    namespace = "com.margelo.mmkv.example"
     defaultConfig {
-        applicationId = "com.mrousavy.mmkv.example"
+        applicationId = "com.margelo.mmkv.example"
         minSdkVersion = rootProject.ext.minSdkVersion
         targetSdkVersion = rootProject.ext.targetSdkVersion
         versionCode = 1

--- a/example/android/app/src/main/java/com/margelo/mmkv/example/MainActivity.kt
+++ b/example/android/app/src/main/java/com/margelo/mmkv/example/MainActivity.kt
@@ -1,4 +1,4 @@
-package com.mrousavy.mmkv.example
+package com.margelo.mmkv.example
 
 import com.facebook.react.ReactActivity
 import com.facebook.react.ReactActivityDelegate

--- a/example/android/app/src/main/java/com/margelo/mmkv/example/MainApplication.kt
+++ b/example/android/app/src/main/java/com/margelo/mmkv/example/MainApplication.kt
@@ -1,4 +1,4 @@
-package com.mrousavy.mmkv.example
+package com.margelo.mmkv.example
 
 import android.app.Application
 import com.facebook.react.PackageList

--- a/example/ios/MmkvExample.xcodeproj/project.pbxproj
+++ b/example/ios/MmkvExample.xcodeproj/project.pbxproj
@@ -274,7 +274,7 @@
 					"-ObjC",
 					"-lc++",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.mrousavy.mmkv.example;
+				PRODUCT_BUNDLE_IDENTIFIER = com.margelo.mmkv.example;
 				PRODUCT_NAME = MmkvExample;
 				SWIFT_ENABLE_EXPLICIT_MODULES = NO;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -303,7 +303,7 @@
 					"-ObjC",
 					"-lc++",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.mrousavy.mmkv.example;
+				PRODUCT_BUNDLE_IDENTIFIER = com.margelo.mmkv.example;
 				PRODUCT_NAME = MmkvExample;
 				SWIFT_ENABLE_EXPLICIT_MODULES = NO;
 				SWIFT_VERSION = 5.0;

--- a/example/rn-harness.config.mjs
+++ b/example/rn-harness.config.mjs
@@ -24,7 +24,7 @@ const config = {
           heapSize: '1G',
         }
       ),
-      bundleId: 'com.mrousavy.mmkv.example',
+      bundleId: 'com.margelo.mmkv.example',
     }),
     applePlatform({
       name: 'ios',
@@ -32,7 +32,7 @@ const config = {
         process.env.HARNESS_IOS_DEVICE ?? 'iPhone 17 Pro',
         process.env.HARNESS_IOS_VERSION ?? '26.5'
       ),
-      bundleId: 'com.mrousavy.mmkv.example',
+      bundleId: 'com.margelo.mmkv.example',
     }),
     webPlatform({
       name: 'web',

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "react-native-mmkv-monorepo",
   "private": true,
   "version": "4.3.2",
-  "repository": "https://github.com/mrousavy/react-native-mmkv.git",
+  "repository": "https://github.com/margelo/react-native-mmkv.git",
   "author": "Marc Rousavy <me@mrousavy.com> (https://github.com/mrousavy)",
   "workspaces": [
     "packages/react-native-mmkv",

--- a/packages/react-native-mmkv/NitroMmkv.podspec
+++ b/packages/react-native-mmkv/NitroMmkv.podspec
@@ -11,7 +11,7 @@ Pod::Spec.new do |s|
   s.authors      = package["author"]
 
   s.platforms    = { :ios => min_ios_version_supported, :visionos => 1.0, :tvos => "12.0", :osx => "10.14" }
-  s.source       = { :git => "https://github.com/mrousavy/react-native-mmkv.git", :tag => "#{s.version}" }
+  s.source       = { :git => "https://github.com/margelo/react-native-mmkv.git", :tag => "#{s.version}" }
 
   s.source_files = [
     # Implementation (Swift)

--- a/packages/react-native-mmkv/README.md
+++ b/packages/react-native-mmkv/README.md
@@ -1,3 +1,3 @@
 # react-native-mmkv
 
-See https://github.com/mrousavy/react-native-mmkv
+See https://github.com/margelo/react-native-mmkv

--- a/packages/react-native-mmkv/package.json
+++ b/packages/react-native-mmkv/package.json
@@ -47,14 +47,14 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/mrousavy/react-native-mmkv.git"
+    "url": "git+https://github.com/margelo/react-native-mmkv.git"
   },
   "author": "Marc Rousavy <me@mrousavy.com> (https://github.com/mrousavy)",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/mrousavy/react-native-mmkv/issues"
+    "url": "https://github.com/margelo/react-native-mmkv/issues"
   },
-  "homepage": "https://github.com/mrousavy/react-native-mmkv#readme",
+  "homepage": "https://github.com/margelo/react-native-mmkv#readme",
   "publishConfig": {
     "registry": "https://registry.npmjs.org/"
   },

--- a/packages/react-native-mmkv/src/__tests__/hooks.test.tsx
+++ b/packages/react-native-mmkv/src/__tests__/hooks.test.tsx
@@ -72,7 +72,7 @@ test('functional updates to hooks', () => {
   const button = screen.getByTestId('button')
 
   // Why these assertions:
-  // https://github.com/mrousavy/react-native-mmkv/issues/599
+  // https://github.com/margelo/react-native-mmkv/issues/599
   fireEvent.press(button)
   expect(screen.getByTestId('state-value').children).toStrictEqual([
     'State: ',


### PR DESCRIPTION
`react-native-mmkv` moved from `mrousavy` to the `margelo` org. This updates everything in-repo that referenced the old path.

## Changed

- **Repo URLs → `margelo/react-native-mmkv`**: root `package.json` `repository`; package `repository.url`, `bugs.url`, `homepage`; `NitroMmkv.podspec` `s.source`; `README.md`, `README_V3.md` (all `blob/v3/docs/*` links), `packages/react-native-mmkv/README.md`, and the issue link in `hooks.test.tsx`.
- **Nitro URLs → `margelo/nitro`**: `mrousavy/nitro` transferred to the org as well, so the `README.md` feature bullet and the `docs/V4_UPGRADE_GUIDE.md` install link now point there.
- **Example app bundle ID → `com.margelo.mmkv.example`**: Android `namespace` + `applicationId`, Kotlin package (files moved `com/mrousavy/mmkv/example` → `com/margelo/mmkv/example`), iOS `PRODUCT_BUNDLE_IDENTIFIER` in both configs, and both entries in `example/rn-harness.config.mjs`. Example app only - nothing published.

## Deliberately not changed

- `packages/react-native-mmkv/nitrogen/generated/**` - the `mrousavy/nitro` header comments are emitted by nitrogen itself, and the `Run Nitrogen` workflow fails on any diff after regenerating. These update when nitrogen does.
- `mrousavy/StorageBenchmark` links - that repo did not move.
- Personal branding and funding: follow badges, `github.com/sponsors/mrousavy`, the enterprise-support mailto, `.github/FUNDING.yml`, and the `author` fields. Ownership of the repo doesn't change who gets sponsored.

## Needs action outside this repo

- **npm**: `react-native-mmkv` is solely owned by npm user `mrousavy`. Consider adding a margelo org/team as owner so releases aren't tied to one account.
- **GitHub repo homepage** is still `https://mrousavy.com`.
- **HTTPS git credentials**: the org forbids classic PATs, so `git push` over the HTTPS remote returns 403. Switch the remote to SSH or swap the stored token for a fine-grained one.
- No repo Actions secrets, variables, webhooks, deployments, or Pages exist, and no Vercel project is linked to this repo - nothing to migrate there. Worth confirming no Vercel project still points at the old `mrousavy/react-native-mmkv` path.