### PR TITLE
fix: stop bundlers inlining JEST_WORKER_ID into isTest()

### DIFF
--- a/packages/react-native-mmkv/src/isTest.ts
+++ b/packages/react-native-mmkv/src/isTest.ts
@@ -3,7 +3,19 @@ export function isTest(): boolean {
     // In a WebBrowser/Electron the `process` variable does not exist
     return false
   }
-  return (
-    process.env.JEST_WORKER_ID != null || process.env.VITEST_WORKER_ID != null
-  )
+  // Read through a variable rather than as `process.env.JEST_WORKER_ID`.
+  //
+  // Metro parallelises transforms with jest-worker, which sets JEST_WORKER_ID
+  // in each worker process, and bundlers such as babel-preset-expo inline
+  // static `process.env.X` member expressions at transform time -- including
+  // inside node_modules. The transform worker's id therefore gets baked into
+  // the app bundle as a literal, isTest() returns true in a normal debug or
+  // release build, and createMMKV() silently returns the in-memory mock.
+  // Storage then appears to work in-session but is never written to disk.
+  //
+  // Only static member expressions are inlined, so indexing a variable sees
+  // the real runtime environment. Jest and Vitest still set these at runtime
+  // in their workers, so genuine test runs are unaffected.
+  const env: Record<string, string | undefined> = global.process.env || {}
+  return Boolean(env['JEST_WORKER_ID'] || env['VITEST_WORKER_ID'])
 }


### PR DESCRIPTION
### Problem

`isTest()` returns `true` in ordinary app builds, so `createMMKV()` silently returns `createMockMMKV()`. Reads and writes succeed and `getAllKeys()` works, but nothing is ever written to disk and every store is empty on the next launch.

The chain:

1. Metro parallelises transforms using **`jest-worker`**, which sets `JEST_WORKER_ID` in each worker process.
2. Bundlers such as **`babel-preset-expo`** inline static `process.env.X` member expressions at transform time, including inside `node_modules`.
3. The transform worker's id is therefore baked into the app bundle as a string literal.
4. `isTest()` reads it, concludes it is under test, and hands back the mock.

Grepping the compiled bundle for `isTest`:

```js
function isTest() {
  if (global.process == null) { return false; }
  return Boolean("6") || Boolean(process.env.VITEST_WORKER_ID);
}
```

`"6"` is Metro transform worker #6 — a literal. `JEST_WORKER_ID` is unset in the shell, in `.env*`, and in the Metro process itself; it exists only inside the transform worker.

This is hard to diagnose because it fails silently and leaves almost no trace: MMKV's core logs initialisation but never an instance (no `loadFromFile`, no `mmap`, no `open fd`), and `existsMMKV(id)` is `false` for every store. Both Nitro's `Logger` and MMKV's core are quiet at default log levels.

### Fix

Index a variable instead of using a static member expression. Only static `process.env.X` reads are inlined, so this sees the real runtime environment. Jest and Vitest still set these variables at runtime in their workers, so genuine test runs continue to get the mock.

### Verification

Tested on device (Samsung SM-A065F, Android 15, arm64-v8a) with Expo 57.0.15, RN 0.86.2, mmkv 4.3.2, metro 0.84.5, babel-preset-expo 57.0.7.

Before: `files/mmkv` never created, `existsMMKV()` `false`, all data lost on restart.

After: all stores create `<id>` and `<id>.crc`, MMKV performs real I/O (`mmap`, `expandAndWriteBack`), and a force-stop + relaunch loads the data back:

```
loaded [base-storage]  with 10 key-values   (11210 bytes, crc verified)
loaded [redux-storage] with 1 key-values    (60785 bytes, crc verified)
```

### Notes

Related reports: #1011 and #1030 (both closed, same signature — #1030 in particular notes MMKV "didn't create a new folder or read the existing one" while other storage libraries worked in the same directory). Not using closing keywords since both are already closed.

Source only — `lib/` is generated at publish time.

In our case this presented as users being randomly logged out, because the session was never on disk to begin with. Any Expo app on v4 is affected, in debug and release alike.
